### PR TITLE
fixed h2v2 and h2v1 downsample func when VLEN = 512

### DIFF
--- a/simd/rvv/jcsample-rvv.c
+++ b/simd/rvv/jcsample-rvv.c
@@ -63,7 +63,7 @@ void jsimd_h2v1_downsample_rvv(JDIMENSION image_width,
 
   /* TODO: If there exists a better way to generate bias sequence. */
   /* Bias */
-  size_t vl = vsetvl_e16m4(output_cols * 2);
+  size_t vl = vsetvl_e16m4(output_cols);
   uint16_t *bias = NULL;
   if (NULL == (bias = (uint16_t *)malloc(vl * sizeof(uint16_t))))
   {
@@ -88,7 +88,7 @@ void jsimd_h2v1_downsample_rvv(JDIMENSION image_width,
     for (outcol = output_cols; outcol > 0;
          outcol -= vl, inptr += vl * 2, outptr += vl)
     {
-      vl = vsetvl_e16m4(outcol * 2);
+      vl = vsetvl_e16m4(outcol);
 
       /* Load samples and the adjacent ones. */
       this = vlse8_v_u8m2(inptr, 2 * sizeof(JSAMPLE), vl);
@@ -128,7 +128,7 @@ void jsimd_h2v2_downsample_rvv(JDIMENSION image_width, int max_v_samp_factor,
 
   /* TODO: If there exists a better way to generate bias sequence. */
   /* Bias */
-  size_t vl = vsetvl_e16m4(output_cols * 2);
+  size_t vl = vsetvl_e16m4(output_cols);
   uint16_t *bias = NULL;
   if (NULL == (bias = (uint16_t *)malloc(vl * sizeof(uint16_t))))
   {
@@ -154,7 +154,7 @@ void jsimd_h2v2_downsample_rvv(JDIMENSION image_width, int max_v_samp_factor,
     for (outcol = output_cols; outcol > 0;
          outcol -= vl, inptr0 += vl * 2, inptr1 += vl * 2, outptr += vl)
     {
-      vl = vsetvl_e16m4(outcol * 2);
+      vl = vsetvl_e16m4(outcol);
 
       /* Load samples and the adjacent ones of two rows. */
       this0 = vlse8_v_u8m2(inptr0, 2 * sizeof(JSAMPLE), vl);


### PR DESCRIPTION
When VLEN is 512, h2v2 downsample will generate 1024 output (it should be 960) and overwrites JPEG header.
And this patch fix that issue.

![table_of_experiments](https://github.com/isrc-cas/libjpeg-turbo/assets/157470524/aa561d1c-0d73-46a9-9157-38d19a21f380)
